### PR TITLE
Chore/absolute imports

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { ChakraProvider } from "@chakra-ui/react"
 
-import theme from "../theme"
+import theme from "theme"
 
 function App({ Component, pageProps }) {
   return (

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,6 +1,6 @@
 import Document, { Head, Html, Main, NextScript } from "next/document"
 
-import { Imports } from "../components/MathJax"
+import { Imports } from "components/MathJax"
 
 class MyDocument extends Document {
   static async getInitialProps(ctx) {

--- a/pages/api/[...route].js
+++ b/pages/api/[...route].js
@@ -1,5 +1,5 @@
-import Test from "../../app/controllers/test"
-import Matrix from "../../app/controllers/matrix"
+import Test from "app/controllers/test"
+import Matrix from "app/controllers/matrix"
 
 const app = require("express")()
 

--- a/pages/mathLibrary.js
+++ b/pages/mathLibrary.js
@@ -1,6 +1,6 @@
 import { Flex, Text, Table, Thead, Tbody, Tr, Th, Td } from "@chakra-ui/react"
 
-import { MathTypeset } from "../components/MathJax"
+import { MathTypeset } from "components/MathJax"
 
 const Index = () => {
   return (


### PR DESCRIPTION
## Problem

Want to enable absolute imports to reduce the need of imports like this `"../../../components/MathJax"`

## Solution

Create `jsconfig.json`

## Notes

Does not apply to `require`