### PR TITLE
chore: add checklist section in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,9 @@
 
 ## Solution
 
+## Checklist
+
+- [ ] If the branch was not created off latest `develop`, merge locally
+- [ ] Using latest `develop` and `master`, do `git diff --stat master` while in `develop` branch. Ensure that the diff is not too large
+
 ## Notes


### PR DESCRIPTION
## Problem

The diff for #25 (or #28) is quite large, with varying scopes in the PRs merged. It includes the following:

- Chore/code coverage [`#23`](https://github.com/weiseng18/math/pull/23)
- Feat/rref [`#22`](https://github.com/weiseng18/math/pull/22)
- Feat/determinant frontend [`#21`](https://github.com/weiseng18/math/pull/21)
- Feat/recursive determinant [`#20`](https://github.com/weiseng18/math/pull/20)
- chore: bump version to 0.3.1 [`#18`](https://github.com/weiseng18/math/pull/18)

There could have been a minor version bump between #21 and #22 as the scope of the changes are different.

## Solution

Add a checklist to PR template, to ensure that `diff` between `develop` and `master` is checked first to see if a version bump should be made

## Notes
