### PR TITLE
Feat/matrix inverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ API: `/api/matrix/rref?matrix=[[1,2],[3,4]]`
 
 Description: Reduces a matrix to RREF. The algorithm used first reduces the matrix to a REF form, then to RREF form.
 
+### Inverse of a square matrix
+
+Frontend page: `/matrix`
+
+Frontend usage: `inv [[1,2],[3,4]]` or `inverse [[1,2],[3,4]]`
+
+API: `/api/matrix/inverse?matrix=[[1,2],[3,4]]`
+
+Description: Obtains the inverse of a matrix. The algorithm used reduces the original matrix to RREF while playing the same row operations onto an identity matrix of the same dimensions.
+
 ## Caveats
 
 - Does not support fraction input

--- a/app/classes/Matrix.ts
+++ b/app/classes/Matrix.ts
@@ -281,6 +281,19 @@ class SquareMatrix extends BaseMatrix {
 
     return determinant
   }
+
+  /**
+   * Checks if the matrix is the identity matrix.
+   * @returns boolean
+   */
+  isIdentity() {
+    for (let i = 0; i < this.rows; i++)
+      for (let j = 0; j < this.columns; j++) {
+        if (i == j && this.entries[i][j] !== 1) return false
+        else if (i != j && this.entries[i][j] !== 0) return false
+      }
+    return true
+  }
 }
 
 export { Matrix, SquareMatrix }

--- a/app/classes/Matrix.ts
+++ b/app/classes/Matrix.ts
@@ -341,7 +341,7 @@ class SquareMatrix extends BaseMatrix {
       // copied action object, adding inverse
       const newAction = {
         ...step,
-        inverse: identity.entries,
+        inverse: _.cloneDeep(identity.entries),
       }
       actions.push(newAction)
     })

--- a/app/classes/Matrix.ts
+++ b/app/classes/Matrix.ts
@@ -1,6 +1,6 @@
 import { range } from "../utils/misc"
 
-import { EchelonType } from "../types/Matrix"
+import { EchelonType, RowOperation } from "../types/Matrix"
 import { leadingEntryIndex } from "../utils/Matrix"
 
 import * as _ from "lodash"
@@ -137,7 +137,7 @@ abstract class BaseMatrix {
     let actions = [] // array of actions done during REF
 
     actions.push({
-      action: "none",
+      action: RowOperation.NONE,
       params: [],
       matrix: _.cloneDeep(this.entries),
     })
@@ -167,7 +167,7 @@ abstract class BaseMatrix {
         if (rowsDone !== firstEntryRowIdx) {
           this.swapRows(rowsDone, firstEntryRowIdx)
           actions.push({
-            action: "swap",
+            action: RowOperation.SWAP,
             params: [rowsDone, firstEntryRowIdx],
             matrix: _.cloneDeep(this.entries),
           })
@@ -179,7 +179,7 @@ abstract class BaseMatrix {
           const factor = (this.entries[i][colIdx] / pivotValue) * -1
           this.addMultiple(rowsDone, factor, i)
           actions.push({
-            action: "addMultiple",
+            action: RowOperation.ADD_MULTIPLE,
             params: [rowsDone, factor, i],
             matrix: _.cloneDeep(this.entries),
           })
@@ -211,7 +211,7 @@ abstract class BaseMatrix {
         if (factor !== 1) {
           this.multiplyRow(rowIdx, factor)
           actions.push({
-            action: "multiplyRow",
+            action: RowOperation.MULTIPLY_ROW,
             params: [rowIdx, factor],
             matrix: _.cloneDeep(this.entries),
           })
@@ -229,7 +229,7 @@ abstract class BaseMatrix {
         if (factor !== 0) {
           this.addMultiple(i, factor, j)
           actions.push({
-            action: "addMultiple",
+            action: RowOperation.ADD_MULTIPLE,
             params: [i, factor, j],
             matrix: _.cloneDeep(this.entries),
           })

--- a/app/classes/Matrix.ts
+++ b/app/classes/Matrix.ts
@@ -303,6 +303,10 @@ class SquareMatrix extends BaseMatrix {
    * The same actions are played onto an identity matrix, giving us the inverse matrix.
    */
   inverse() {
+    // if matrix is singular, throw error that the matrix is singular
+    if (this.calcDeterminant() === 0)
+      throw new Error("Matrix is singular; No inverse exists")
+
     const rrefActions = this.toRREF()
 
     // create identity matrix

--- a/app/classes/Matrix.ts
+++ b/app/classes/Matrix.ts
@@ -294,6 +294,57 @@ class SquareMatrix extends BaseMatrix {
       }
     return true
   }
+
+  /**
+   * Calculates the inverse matrix of the current matrix.
+   *
+   * It performs RREF on the current matrix, obtaining the actions array.
+   * The actions array describes the row operations done to perform RREF.
+   * The same actions are played onto an identity matrix, giving us the inverse matrix.
+   */
+  inverse() {
+    const rrefActions = this.toRREF()
+
+    // create identity matrix
+    const identity = new SquareMatrix({
+      rows: this.rows,
+      columns: this.columns,
+    })
+    range(this.rows).forEach((i) => {
+      identity.entries[i][i] = 1
+    })
+
+    // play the actions onto the identity matrix, while storing the intermediate states
+    let actions: {
+      inverse: number[][]
+      action: RowOperation
+      params: number[]
+      matrix: number[][]
+    }[] = []
+
+    rrefActions.forEach((step) => {
+      // what action to perform onto the identity matrix
+      const actionToPerform = step.action
+      const params = step.params
+      if (actionToPerform === RowOperation.ADD_MULTIPLE) {
+        identity.addMultiple(params[0], params[1], params[2])
+      } else if (actionToPerform === RowOperation.MULTIPLY_ROW) {
+        identity.multiplyRow(params[0], params[1])
+      } else if (actionToPerform === RowOperation.SWAP) {
+        identity.swapRows(params[0], params[1])
+      }
+
+      // copied action object, adding inverse
+      const newAction = {
+        ...step,
+        inverse: identity.entries,
+      }
+      actions.push(newAction)
+    })
+
+    this.entries = identity.entries
+    return actions
+  }
 }
 
 export { Matrix, SquareMatrix }

--- a/app/controllers/matrix.ts
+++ b/app/controllers/matrix.ts
@@ -74,7 +74,7 @@ const calcInverse = (req: VercelRequest, res: VercelResponse) => {
     const actions = squareMatrix.inverse()
     res.json({
       actions,
-      matrix: matrix.entries,
+      matrix: squareMatrix.entries,
     })
   } catch (err) {
     res.status(500).json({ message: err.message })

--- a/app/controllers/matrix.ts
+++ b/app/controllers/matrix.ts
@@ -54,7 +54,35 @@ const reduceRREF = (req: VercelRequest, res: VercelResponse) => {
   }
 }
 
+const calcInverse = (req: VercelRequest, res: VercelResponse) => {
+  try {
+    let matrix
+    // string array
+    if (Array.isArray(req.query.matrix))
+      matrix = JSON.parse(req.query.matrix.join())
+    else matrix = JSON.parse(req.query.matrix)
+
+    const rows = matrix.length
+    const cols = matrix[0].length
+
+    const squareMatrix = new SquareMatrix({
+      rows,
+      columns: cols,
+      entries: matrix,
+    })
+
+    const actions = squareMatrix.inverse()
+    res.json({
+      actions,
+      matrix: matrix.entries,
+    })
+  } catch (err) {
+    res.status(500).json({ message: err.message })
+  }
+}
+
 export default {
   calcDeterminant,
   reduceRREF,
+  calcInverse,
 }

--- a/app/tests/index.ts
+++ b/app/tests/index.ts
@@ -26,6 +26,10 @@ const toTest = [
     route: "/matrix/determinant",
     method: Matrix.calcDeterminant,
   },
+  {
+    route: "/matrix/inverse",
+    method: Matrix.calcInverse,
+  },
 ]
 
 chai.use(chaiHttp)
@@ -101,6 +105,51 @@ describe("API tests", () => {
           chai
             .expect(res.body.message)
             .to.equal("Row and column counts do not match")
+        })
+    })
+  })
+
+  describe("/api/matrix/inverse", () => {
+    before(start)
+    after(stop)
+
+    it("should return inverse of 3 by 3 matrix", async () => {
+      await chai
+        .request(url)
+        .get(route)
+        .query({
+          matrix: "[[1,0,0],[0,4,0],[0,0,2]]",
+        })
+        .then((res) => {
+          chai.expect(res.status).to.equal(200)
+        })
+    })
+    it("should obtain 500 for 3 by 2 matrix", async () => {
+      await chai
+        .request(url)
+        .get(route)
+        .query({
+          matrix: "[[1,2],[3,4],[5,6]]",
+        })
+        .then((res) => {
+          chai.expect(res.status).to.equal(500)
+          chai
+            .expect(res.body.message)
+            .to.equal("Row and column counts do not match")
+        })
+    })
+    it("should obtain 500 for singular square matrix", async () => {
+      await chai
+        .request(url)
+        .get(route)
+        .query({
+          matrix: "[[1,2],[0,0]]",
+        })
+        .then((res) => {
+          chai.expect(res.status).to.equal(500)
+          chai
+            .expect(res.body.message)
+            .to.equal("Matrix is singular; No inverse exists")
         })
     })
   })

--- a/app/tests/unit/matrix.ts
+++ b/app/tests/unit/matrix.ts
@@ -281,4 +281,44 @@ export default () => {
       })
     })
   })
+
+  describe("inverse", () => {
+    it("should return inverse correctly, for non-singular square matrices", () => {
+      const matrices = [
+        [
+          [1, 0, 0],
+          [0, 4, 0],
+          [0, 0, 2],
+        ],
+        [
+          [1, 2, 4],
+          [2, 3, 5],
+          [3, 4, 5],
+        ],
+      ]
+      const inverses = [
+        [
+          [1, 0, 0],
+          [0, 1 / 4, 0],
+          [0, 0, 1 / 2],
+        ],
+        [
+          [-5, 6, -2],
+          [5, -7, 3],
+          [-1, 2, -1],
+        ],
+      ]
+      matrices.forEach((arr, idx) => {
+        const matrix = new SquareMatrix({
+          rows: arr.length,
+          columns: arr[0].length,
+          entries: arr,
+        })
+        const actions = matrix.inverse()
+        // compare with the answer
+        const inverse = inverses[idx]
+        chai.expect(matrix.entries).to.eql(inverse)
+      })
+    })
+  })
 }

--- a/app/tests/unit/matrix.ts
+++ b/app/tests/unit/matrix.ts
@@ -2,9 +2,10 @@
 import chai from "chai"
 
 import { EchelonType } from "../../types/Matrix"
+import { range } from "../../utils/misc"
 
 // import stuff to be tested
-import { Matrix } from "../../classes/Matrix"
+import { Matrix, SquareMatrix } from "../../classes/Matrix"
 
 export default () => {
   describe("echelonStatus", () => {
@@ -237,6 +238,46 @@ export default () => {
         const actions = matrix.toRREF()
         const res = matrix.echelonStatus()
         chai.expect(res).to.equal(EchelonType.RREF)
+      })
+    })
+  })
+
+  describe("isIdentity", () => {
+    it("should return true for identity matrices", () => {
+      range(5).forEach((val) => {
+        const length = val + 1
+        // create identity matrix of size length
+        const matrix = new SquareMatrix({ rows: length, columns: length })
+        range(length).forEach((i) => {
+          matrix.entries[i][i] = 1
+        })
+        // check
+        const res = matrix.isIdentity()
+        chai.expect(res).to.equal(true)
+      })
+    })
+    it("should return false for non-identity matrices", () => {
+      const matrices = [
+        [
+          [1, 2, 3],
+          [2, 3, 4],
+          [3, 4, 5],
+        ],
+        [
+          [1, 0, 0],
+          [0, 3, 0],
+          [0, 0, 2],
+        ],
+      ]
+      matrices.forEach((arr) => {
+        const matrix = new SquareMatrix({
+          rows: arr.length,
+          columns: arr.length,
+          entries: arr,
+        })
+        // check
+        const res = matrix.isIdentity()
+        chai.expect(res).to.equal(false)
       })
     })
   })

--- a/app/types/Matrix.ts
+++ b/app/types/Matrix.ts
@@ -4,4 +4,11 @@ enum EchelonType {
   RREF = "Reduced row echelon form",
 }
 
-export { EchelonType }
+enum RowOperation {
+  NONE = "none",
+  ADD_MULTIPLE = "addMultiple",
+  MULTIPLY_ROW = "multiplyRow",
+  SWAP = "swap",
+}
+
+export { EchelonType, RowOperation }

--- a/pages/api/[...route].js
+++ b/pages/api/[...route].js
@@ -7,5 +7,6 @@ app.get("/api/test", Test.test)
 
 app.get("/api/matrix/determinant", Matrix.calcDeterminant)
 app.get("/api/matrix/rref", Matrix.reduceRREF)
+app.get("/api/matrix/inverse", Matrix.calcInverse)
 
 module.exports = app

--- a/pages/matrix.js
+++ b/pages/matrix.js
@@ -54,6 +54,9 @@ const Page = () => {
       const action = arr.shift()
       const matrix = arr.join(" ")
 
+      // to setInputArray(matrixArray) later
+      const matrixArray = JSON.parse(matrix)
+
       let res
       switch (action) {
         case "determinant":
@@ -63,7 +66,7 @@ const Page = () => {
               matrix,
             },
           })
-          setQuestion("\\mathrm{det}")
+          setQuestion("\\mathrm{det}" + convert2DArrayToMatrix(matrixArray))
           setAnswer(res.data)
           setActions([])
           Router.push({
@@ -77,7 +80,7 @@ const Page = () => {
               matrix,
             },
           })
-          setQuestion("\\mathrm{inverse}")
+          setQuestion("\\mathrm{inverse}" + convert2DArrayToMatrix(matrixArray))
           setAnswer(convert2DArrayToMatrix(res.data.matrix))
           setActions(res.data.actions)
           Router.push({
@@ -90,7 +93,7 @@ const Page = () => {
               matrix,
             },
           })
-          setQuestion("\\mathrm{rref}")
+          setQuestion("\\mathrm{rref}" + convert2DArrayToMatrix(matrixArray))
           setAnswer(convert2DArrayToMatrix(res.data.matrix))
           setActions(res.data.actions)
           Router.push({
@@ -103,7 +106,7 @@ const Page = () => {
           setActions([])
           throw new Error("Unrecognized command")
       }
-      setInputArray(JSON.parse(matrix))
+      setInputArray(matrixArray)
 
       // force math typesetting
       MathJax.typeset()
@@ -177,10 +180,7 @@ const Page = () => {
               <Text>${convert2DArrayToMatrix(inputArray)}$</Text>
             </HStack>
             <HStack spacing={1} bgColor="gray.200" padding={4}>
-              <Text>
-                ${question}
-                {convert2DArrayToMatrix(inputArray)} = $
-              </Text>
+              <Text>${question} = $</Text>
               <Text>${answer}$</Text>
             </HStack>
             {router.query.action &&

--- a/pages/matrix.js
+++ b/pages/matrix.js
@@ -110,6 +110,7 @@ const Page = () => {
 
       setLoading(false)
     } catch (err) {
+      setLoading(false)
       setError(err.message)
     }
   }

--- a/pages/matrix.js
+++ b/pages/matrix.js
@@ -130,6 +130,8 @@ const Page = () => {
         setInputArray([[]])
         setAnswer("")
       }
+    } else {
+      MathJax.typeset()
     }
   }, [router.query])
 

--- a/pages/matrix.js
+++ b/pages/matrix.js
@@ -27,8 +27,9 @@ const Page = () => {
   const [inputArray, setInputArray] = useState([[]]) // matrix from processed query
   const [answer, setAnswer] = useState("") // Latex string
 
-  // only for rref
-  const [rrefActions, setRrefActions] = useState([])
+  // only for rref or inverse
+  // holds the data for intermediate steps
+  const [actions, setActions] = useState([])
 
   const router = useRouter()
 
@@ -64,7 +65,7 @@ const Page = () => {
           })
           setCommand("\\mathrm{det}")
           setAnswer(res.data)
-          setRrefActions([])
+          setActions([])
           Router.push({
             query: { action: "det", matrix },
           })
@@ -78,7 +79,7 @@ const Page = () => {
           })
           setCommand("\\mathrm{inverse}")
           setAnswer(convert2DArrayToMatrix(res.data.matrix))
-          setRrefActions(res.data.actions)
+          setActions(res.data.actions)
           Router.push({
             query: { action: "inverse", matrix },
           })
@@ -91,7 +92,7 @@ const Page = () => {
           })
           setCommand("\\mathrm{rref}")
           setAnswer(convert2DArrayToMatrix(res.data.matrix))
-          setRrefActions(res.data.actions)
+          setActions(res.data.actions)
           Router.push({
             query: { action: "rref", matrix },
           })
@@ -99,7 +100,7 @@ const Page = () => {
         default:
           setLoading(false)
           setAnswer("")
-          setRrefActions([])
+          setActions([])
           throw new Error("Unrecognized command")
       }
       setInputArray(JSON.parse(matrix))
@@ -183,12 +184,12 @@ const Page = () => {
             </HStack>
             {router.query.action &&
               router.query.action === "rref" &&
-              rrefActions.length > 0 &&
-              rrefSteps(rrefActions)}
+              actions.length > 0 &&
+              rrefSteps(actions)}
             {router.query.action &&
               router.query.action === "inverse" &&
-              rrefActions.length > 0 &&
-              inverseSteps(rrefActions)}
+              actions.length > 0 &&
+              inverseSteps(actions)}
           </VStack>
         )}
       </VStack>

--- a/pages/matrix.js
+++ b/pages/matrix.js
@@ -23,7 +23,7 @@ const Page = () => {
 
   const [loading, setLoading] = useState(true) // if page is loading or handleSubmit is running
 
-  const [command, setCommand] = useState("") // action from processed query
+  const [question, setQuestion] = useState("") // action from processed query
   const [inputArray, setInputArray] = useState([[]]) // matrix from processed query
   const [answer, setAnswer] = useState("") // Latex string
 
@@ -63,7 +63,7 @@ const Page = () => {
               matrix,
             },
           })
-          setCommand("\\mathrm{det}")
+          setQuestion("\\mathrm{det}")
           setAnswer(res.data)
           setActions([])
           Router.push({
@@ -77,7 +77,7 @@ const Page = () => {
               matrix,
             },
           })
-          setCommand("\\mathrm{inverse}")
+          setQuestion("\\mathrm{inverse}")
           setAnswer(convert2DArrayToMatrix(res.data.matrix))
           setActions(res.data.actions)
           Router.push({
@@ -90,7 +90,7 @@ const Page = () => {
               matrix,
             },
           })
-          setCommand("\\mathrm{rref}")
+          setQuestion("\\mathrm{rref}")
           setAnswer(convert2DArrayToMatrix(res.data.matrix))
           setActions(res.data.actions)
           Router.push({
@@ -166,7 +166,7 @@ const Page = () => {
         )}
         {answer !== "" && (
           <VStack
-            key={inputArray.join() + command}
+            key={inputArray.join() + question}
             spacing={8}
             pt={8}
             w="100%"
@@ -178,7 +178,7 @@ const Page = () => {
             </HStack>
             <HStack spacing={1} bgColor="gray.200" padding={4}>
               <Text>
-                ${command}
+                ${question}
                 {convert2DArrayToMatrix(inputArray)} = $
               </Text>
               <Text>${answer}$</Text>

--- a/pages/matrix.js
+++ b/pages/matrix.js
@@ -80,7 +80,7 @@ const Page = () => {
               matrix,
             },
           })
-          setQuestion("\\mathrm{inverse}" + convert2DArrayToMatrix(matrixArray))
+          setQuestion(convert2DArrayToMatrix(matrixArray) + "^{-1}")
           setAnswer(convert2DArrayToMatrix(res.data.matrix))
           setActions(res.data.actions)
           Router.push({

--- a/utils.js
+++ b/utils.js
@@ -20,4 +20,41 @@ const convert2DArrayToMatrix = (array) => {
   return mathString
 }
 
-export { convert2DArrayToMatrix }
+/**
+ * Converts two Javascript 2D arrays into a string that represents the augmented matrix in Latex.
+ * @param {*} left 2-dimensional array
+ * @param {*} right 2-dimensional array
+ * @returns Escaped Latex string
+ */
+const convert2DArraysToAugmentedMatrix = (left, right) => {
+  const rowCount = left.length
+
+  const leftColCount = left[0].length
+  const rightColCount = right[0].length
+
+  // define augmented matrix environment
+  const env =
+    "\\newenvironment{sysmatrix}[1]{\\left(\\begin{array}{@{}#1@{}}}{\\end{array}\\right)}"
+
+  const prefix = "\\begin{sysmatrix}"
+  const suffix = "\\end{sysmatrix}"
+
+  let columns = "{"
+  for (let i = 0; i < leftColCount; i++) columns += "c"
+  columns += "|"
+  for (let i = 0; i < rightColCount; i++) columns += "c"
+  columns += "}"
+
+  let mathString = env + prefix + columns
+  left.forEach((row, idx) => {
+    const leftString = row.join(" & ")
+    const rightString = right[idx].join(" & ")
+    const lineBreak = idx == rowCount - 1 ? "" : "\\\\"
+    mathString += leftString + " & " + rightString + lineBreak
+  })
+  mathString += suffix
+
+  return mathString
+}
+
+export { convert2DArrayToMatrix, convert2DArraysToAugmentedMatrix }


### PR DESCRIPTION
## Problem

Want to implement matrix inverse

## Solution

- Matrix inverse computation is done by doing RREF on the original matrix, and playing the same row operations onto a identity matrix

<ins>Refactoring</ins>

- Created enum `RowOperation` in backend for better readability
- Minor refactoring in frontend to allow for operations that are not necessarily represented as `f(x)`

## Checklist

- [x] If the branch was not created off latest `develop`, merge locally
- [x] Using latest `develop` and `master`, do `git diff --stat master` while in `develop` branch. Ensure that the diff is not too large

## Notes

Currently, a `500` is thrown for any kind of error, including client errors. For example, trying to calculate an inverse of a singular matrix results in a `500`, but does not explain why. This should be a `400` instead, but this fix will be done in a separate PR.