### PR TITLE
Feat/error handling

### DIFF
--- a/app/classes/Error.ts
+++ b/app/classes/Error.ts
@@ -1,0 +1,9 @@
+class HttpException {
+  code: number
+  message: string
+  constructor(code: number, message: string) {
+    this.code = code
+    this.message = message
+  }
+}
+export { HttpException }

--- a/app/classes/Matrix.ts
+++ b/app/classes/Matrix.ts
@@ -2,6 +2,7 @@ import { range } from "../utils/misc"
 
 import { EchelonType, RowOperation } from "../types/Matrix"
 import { leadingEntryIndex } from "../utils/Matrix"
+import { HttpException } from "./Error"
 
 import * as _ from "lodash"
 
@@ -250,7 +251,7 @@ class Matrix extends BaseMatrix {
 class SquareMatrix extends BaseMatrix {
   constructor(props: IMatrix) {
     if (props.rows != props.columns)
-      throw new Error("Row and column counts do not match")
+      throw new HttpException(400, "Row and column counts do not match")
     super(props)
   }
 
@@ -305,7 +306,7 @@ class SquareMatrix extends BaseMatrix {
   inverse() {
     // if matrix is singular, throw error that the matrix is singular
     if (this.calcDeterminant() === 0)
-      throw new Error("Matrix is singular; No inverse exists")
+      throw new HttpException(400, "Matrix is singular; No inverse exists")
 
     const rrefActions = this.toRREF()
 

--- a/app/controllers/matrix.ts
+++ b/app/controllers/matrix.ts
@@ -1,4 +1,5 @@
 import { VercelRequest, VercelResponse } from "@vercel/node"
+import * as _ from "lodash"
 
 import { Matrix, SquareMatrix } from "../classes/Matrix"
 
@@ -23,7 +24,8 @@ const calcDeterminant = (req: VercelRequest, res: VercelResponse) => {
     const determinant = squareMatrix.calcDeterminant()
     res.json(determinant)
   } catch (err) {
-    res.status(500).json({ message: err.message })
+    const errorCode = _.get(err, "code", 500)
+    res.status(errorCode).json({ message: err.message })
   }
 }
 
@@ -50,7 +52,8 @@ const reduceRREF = (req: VercelRequest, res: VercelResponse) => {
       matrix: matrix.entries,
     })
   } catch (err) {
-    res.status(500).json({ message: err.message })
+    const errorCode = _.get(err, "code", 500)
+    res.status(errorCode).json({ message: err.message })
   }
 }
 
@@ -77,7 +80,8 @@ const calcInverse = (req: VercelRequest, res: VercelResponse) => {
       matrix: squareMatrix.entries,
     })
   } catch (err) {
-    res.status(500).json({ message: err.message })
+    const errorCode = _.get(err, "code", 500)
+    res.status(errorCode).json({ message: err.message })
   }
 }
 

--- a/app/tests/index.ts
+++ b/app/tests/index.ts
@@ -93,7 +93,7 @@ describe("API tests", () => {
           chai.expect(res.body).to.equal(0)
         })
     })
-    it("should obtain 500 for 3 by 2 matrix", async () => {
+    it("should obtain 400 for 3 by 2 matrix", async () => {
       await chai
         .request(url)
         .get(route)
@@ -101,7 +101,7 @@ describe("API tests", () => {
           matrix: "[[1,2],[3,4],[5,6]]",
         })
         .then((res) => {
-          chai.expect(res.status).to.equal(500)
+          chai.expect(res.status).to.equal(400)
           chai
             .expect(res.body.message)
             .to.equal("Row and column counts do not match")
@@ -124,7 +124,7 @@ describe("API tests", () => {
           chai.expect(res.status).to.equal(200)
         })
     })
-    it("should obtain 500 for 3 by 2 matrix", async () => {
+    it("should obtain 400 for 3 by 2 matrix", async () => {
       await chai
         .request(url)
         .get(route)
@@ -132,13 +132,13 @@ describe("API tests", () => {
           matrix: "[[1,2],[3,4],[5,6]]",
         })
         .then((res) => {
-          chai.expect(res.status).to.equal(500)
+          chai.expect(res.status).to.equal(400)
           chai
             .expect(res.body.message)
             .to.equal("Row and column counts do not match")
         })
     })
-    it("should obtain 500 for singular square matrix", async () => {
+    it("should obtain 400 for singular square matrix", async () => {
       await chai
         .request(url)
         .get(route)
@@ -146,7 +146,7 @@ describe("API tests", () => {
           matrix: "[[1,2],[0,0]]",
         })
         .then((res) => {
-          chai.expect(res.status).to.equal(500)
+          chai.expect(res.status).to.equal(400)
           chai
             .expect(res.body.message)
             .to.equal("Matrix is singular; No inverse exists")

--- a/pages/matrix.js
+++ b/pages/matrix.js
@@ -114,7 +114,7 @@ const Page = () => {
       setLoading(false)
     } catch (err) {
       setLoading(false)
-      setError(err.message)
+      setError(err.response.data.message)
     }
   }
 


### PR DESCRIPTION
## Problem

1. The generic `throw new Error` was previously used, so all errors are `500`. In the two locations it is used, a `400` should be thrown instead.
2. The frontend page `/matrix` was not able to access the actual custom error message, instead it just says `Request failed with status code 500`

## Solution

1. Create a `HttpException` class that accepts a status code to throw non-500 errors easily, and update the two locations to throw a `400` instead.
2. The actual error is located in `err.response.data.message`, and not `err.message`. Update the line

## Checklist

- [ ] If the branch was not created off latest `develop`, merge locally
- [ ] Using latest `develop` and `master`, do `git diff --stat master` while in `develop` branch. Ensure that the diff is not too large

## Notes

Considered writing a middleware to handle the errors, but that would require `next()` which is not part of Vercel's serverless functions structure. I could use `next: Function`, and it would work as expected. However, the API tests use `vercel-node-server`, which is not able to trigger `next()`, and rightfully so since it is not part of Vercel's serverless functions structure.