### PR TITLE
chore: make RELEASE.md more clear

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -4,12 +4,12 @@
 
 - [ ] `git fetch --tags` to get latest tags
 - [ ] `git checkout -b bump/X.X.X` to create branch to bump version number
-- [ ] `npm version major|minor|patch -m "chore: bump version to X.X.X"` to update `package.json` version. This will create a commit. This also triggers `npm run version` before making the commit, so `CHANGELOG.md` will get updated as part of the commit.
-- [ ] Merge bump branch into `develop`
+- [ ] `npm version major|minor|patch -m "chore: bump version to X.X.X"` to update `package.json` version. This will create a commit. This also triggers `npm run version` before making the commit, so `CHANGELOG.md` will get updated as part of the same commit.
+- [ ] Create a PR to merge the bump branch `bump/X.X.X` into `develop`. The PR's comment should be empty.
 - [ ] Confirm that the latest tag can be found at https://github.com/weiseng18/math/tags. If not, manually push the tags using the command `git push origin --tags`
 
 ### Merging into `master`
 
 - [ ] Create PR to merge `develop` into `master`, with title `Release: X.X.X: Title`
-- [ ] Copy changes from `CHANGELOG.md`
+- [ ] The PR's comment should contain `This release contains:` and copied changes from `CHANGELOG.md`
 - [ ] Merge `develop` into `master`


### PR DESCRIPTION
## Problem

Improve clarity in `RELEASE.md` to reduce mental load

## Solution

- Added what a release PR should look like
- Added what a bump PR should look like

## Checklist

- [ ] If the branch was not created off latest `develop`, merge locally
- [ ] Using latest `develop` and `master`, do `git diff --stat master` while in `develop` branch. Ensure that the diff is not too large

## Notes
