### PR TITLE
Fix/rendering

### DIFF
--- a/pages/logic.js
+++ b/pages/logic.js
@@ -155,6 +155,7 @@ const Page = () => {
               size="sm"
               w="auto"
               border="solid black 1px"
+              key={expression}
             >
               <Thead>
                 <Tr>

--- a/pages/logic.js
+++ b/pages/logic.js
@@ -95,6 +95,8 @@ const Page = () => {
         setQuery("")
         setBooleans([])
         setAnswers([])
+        setVariables([])
+        setExpression([])
       }
     } else {
       MathJax.typeset()

--- a/pages/logic.js
+++ b/pages/logic.js
@@ -52,7 +52,8 @@ const Page = () => {
     // empty query
     if (query === "" && passedQuery === "") return
 
-    const expr = query === "" ? passedQuery : query
+    // only fall back to query, if passedQuery is empty
+    const expr = passedQuery === "" ? query : passedQuery
 
     try {
       setLoading(true)

--- a/pages/matrix.js
+++ b/pages/matrix.js
@@ -50,7 +50,7 @@ const Page = () => {
       setLoading(true)
 
       // split query into action and matrix
-      let arr = query === "" ? passedQuery.split(" ") : query.split(" ")
+      let arr = passedQuery === "" ? query.split(" ") : passedQuery.split(" ")
       const action = arr.shift()
       const matrix = arr.join(" ")
 


### PR DESCRIPTION
## Problem

On a page with a loaded query, triggering a second query will still show remnants of the previous query.

## Solution

- Give `passedQuery` higher priority than `query`
- Add key to table, to trigger re-render (on `/logic` page)
- Reset all states when clearing data

## Checklist

- [ ] If the branch was not created off latest `develop`, merge locally
- [ ] Using latest `develop` and `master`, do `git diff --stat master` while in `develop` branch. Ensure that the diff is not too large
- [ ] If this is a feature, has appropriate documentation been added?

## Notes

Back/forward still does not work as intended. Issue filed #52 