### PR TITLE
Chore/imports

### DIFF
--- a/app/classes/Matrix.ts
+++ b/app/classes/Matrix.ts
@@ -1,8 +1,9 @@
 import { range } from "../utils/misc"
 
-import { EchelonType, RowOperation } from "../types/Matrix"
-import { leadingEntryIndex } from "../utils/Matrix"
-import { BadRequest } from "./Error"
+import { EchelonType, RowOperation } from "app/types/Matrix"
+import { leadingEntryIndex } from "app/utils/Matrix"
+
+import { BadRequest } from "app/classes/Error"
 
 import * as _ from "lodash"
 

--- a/app/classes/logic/SyntaxTree.ts
+++ b/app/classes/logic/SyntaxTree.ts
@@ -1,6 +1,6 @@
-import { LogicToken, LogicTokenType, BitmaskObject } from "../../types/Logic"
+import { LogicToken, LogicTokenType, BitmaskObject } from "app/types/Logic"
 
-import { BadRequest } from "../Error"
+import { BadRequest } from "app/classes/Error"
 
 class Node {
   value: string

--- a/app/classes/logic/Tokenizer.ts
+++ b/app/classes/logic/Tokenizer.ts
@@ -1,4 +1,4 @@
-import { LogicToken, LogicTokenType, IExpressionInfo } from "../../types/Logic"
+import { LogicToken, LogicTokenType, IExpressionInfo } from "app/types/Logic"
 
 import * as _ from "lodash"
 

--- a/app/classes/logic/TruthTableGenerator.ts
+++ b/app/classes/logic/TruthTableGenerator.ts
@@ -1,8 +1,8 @@
 import * as _ from "lodash"
 
-import { SyntaxTree } from "./SyntaxTree"
+import { SyntaxTree } from "app/classes/logic/SyntaxTree"
 
-import { IExpressionInfo } from "../../types/Logic"
+import { IExpressionInfo } from "app/types/Logic"
 
 class TruthTableGenerator {
   tokens: {

--- a/app/controllers/logic.ts
+++ b/app/controllers/logic.ts
@@ -1,8 +1,8 @@
 import { VercelRequest, VercelResponse } from "@vercel/node"
 import * as _ from "lodash"
 
-import Tokenizer from "../classes/logic/Tokenizer"
-import TruthTableGenerator from "../classes/logic/TruthTableGenerator"
+import Tokenizer from "app/classes/logic/Tokenizer"
+import TruthTableGenerator from "app/classes/logic/TruthTableGenerator"
 
 const generateTruthTable = (req: VercelRequest, res: VercelResponse) => {
   try {

--- a/app/controllers/matrix.ts
+++ b/app/controllers/matrix.ts
@@ -1,7 +1,7 @@
 import { VercelRequest, VercelResponse } from "@vercel/node"
 import * as _ from "lodash"
 
-import { Matrix, SquareMatrix } from "../classes/Matrix"
+import { Matrix, SquareMatrix } from "app/classes/Matrix"
 
 const calcDeterminant = (req: VercelRequest, res: VercelResponse) => {
   try {

--- a/app/tests/index.ts
+++ b/app/tests/index.ts
@@ -9,10 +9,10 @@ import listen from "test-listen"
 // types
 import { Server } from "http"
 
-// import methods to be tested
-import Test from "../controllers/test"
-import Matrix from "../controllers/matrix"
-import Logic from "../controllers/logic"
+// import controller methods to be tested
+import Test from "app/controllers/test"
+import Matrix from "app/controllers/matrix"
+import Logic from "app/controllers/logic"
 
 // beforeEach management
 let route: string, method, server: Server, url: string

--- a/app/tests/unit/logic.ts
+++ b/app/tests/unit/logic.ts
@@ -1,12 +1,12 @@
 // standard testing modules
 import chai from "chai"
 
-import { LogicTokenType } from "../../types/Logic"
+import { LogicTokenType } from "app/types/Logic"
 
-// import stuff to be tested
-import Tokenizer from "../../classes/logic/Tokenizer"
-import { SyntaxTree } from "../../classes/logic/SyntaxTree"
-import TruthTableGenerator from "../../classes/logic/TruthTableGenerator"
+// import classes to be tested
+import Tokenizer from "app/classes/logic/Tokenizer"
+import { SyntaxTree } from "app/classes/logic/SyntaxTree"
+import TruthTableGenerator from "app/classes/logic/TruthTableGenerator"
 
 export default () => {
   describe("Tokenizer", () => {

--- a/app/tests/unit/matrix.ts
+++ b/app/tests/unit/matrix.ts
@@ -1,11 +1,11 @@
 // standard testing modules
 import chai from "chai"
 
-import { EchelonType } from "../../types/Matrix"
-import { range } from "../../utils/misc"
+import { EchelonType } from "app/types/Matrix"
+import { range } from "app/utils/misc"
 
-// import stuff to be tested
-import { Matrix, SquareMatrix } from "../../classes/Matrix"
+// import classes to be tested
+import { Matrix, SquareMatrix } from "app/classes/Matrix"
 
 export default () => {
   describe("echelonStatus", () => {

--- a/app/tests/unit/utils.ts
+++ b/app/tests/unit/utils.ts
@@ -2,8 +2,8 @@
 import chai from "chai"
 
 // import utils to be tested
-import { range } from "../../utils/misc"
-import { isZeroRow, leadingEntryIndex } from "../../utils/Matrix"
+import { range } from "app/utils/misc"
+import { isZeroRow, leadingEntryIndex } from "app/utils/Matrix"
 
 export default () => {
   describe("Misc: range", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "husky": "^7.0.1",
         "mocha": "^9.0.3",
         "nyc": "^15.1.0",
-        "ts-node": "^8.9.1"
+        "ts-node": "^8.9.1",
+        "tsconfig-paths": "^3.10.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -8133,6 +8134,41 @@
         }
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
+      "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.0",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
@@ -14991,6 +15027,34 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw=="
+    },
+    "tsconfig-paths": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
+      "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
+      "dev": true,
+      "requires": {
+        "json5": "^2.2.0",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
     },
     "tslib": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "build": "next build",
     "start": "next start",
     "version": "auto-changelog -p -l 0 && git add CHANGELOG.md",
-    "test": "nyc mocha -r ts-node/register app/tests/index.ts",
-    "test-unit": "nyc mocha -r ts-node/register app/tests/unit/index.ts",
-    "test-ci": "mocha -r ts-node/register app/tests/index.ts",
-    "test-unit-ci": "mocha -r ts-node/register app/tests/unit/index.ts"
+    "test": "nyc mocha -r ts-node/register -r tsconfig-paths/register app/tests/index.ts",
+    "test-unit": "nyc mocha -r ts-node/register -r tsconfig-paths/register app/tests/unit/index.ts",
+    "test-ci": "mocha -r ts-node/register -r tsconfig-paths/register app/tests/index.ts",
+    "test-unit-ci": "mocha -r ts-node/register -r tsconfig-paths/register app/tests/unit/index.ts"
   },
   "repository": {
     "type": "git",
@@ -51,6 +51,7 @@
     "husky": "^7.0.1",
     "mocha": "^9.0.3",
     "nyc": "^15.1.0",
-    "ts-node": "^8.9.1"
+    "ts-node": "^8.9.1",
+    "tsconfig-paths": "^3.10.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,5 +27,8 @@
     "jsx": "preserve",
     "isolatedModules": true,
     "noUnusedLocals": true
+  },
+  "paths": {
+    "app/*": ["./app/*"]
   }
 }


### PR DESCRIPTION
## Problem

Want to enable backend absolute imports (for Typescript)

## Solution

- `/app/*` excluding `/app/tests` already supported absolute imports, so the imports were simply updated
- `/app/tests` required extra work to support absolute imports, when running with `mocha`. `ts-node` [does not support absolute paths](https://github.com/TypeStrong/ts-node/issues/138), and in that page, the [proposed solution](https://github.com/TypeStrong/ts-node/issues/138#issuecomment-269760415) was to use [tsconfig-paths](https://www.npmjs.com/package/tsconfig-paths). The solution was used and it works.

## Checklist

- [x] If the branch was not created off latest `develop`, merge locally
- [x] Using latest `develop` and `master`, do `git diff --stat master` while in `develop` branch. Ensure that the diff is not too large
- [x] If this is a feature, has appropriate documentation been added?

## Notes
