### PR TITLE
Feat/truth table biconditional

### DIFF
--- a/app/classes/logic/SyntaxTree.ts
+++ b/app/classes/logic/SyntaxTree.ts
@@ -167,6 +167,9 @@ class SyntaxTree {
       else if (root.value === LogicToken.IMPLIES)
         // !p || q (implication law)
         return !this.eval(root.left, mask) || this.eval(root.right, mask)
+      else if (root.value === LogicToken.BICONDITIONAL)
+        // true if p === q
+        return this.eval(root.left, mask) === this.eval(root.right, mask)
     } else {
       // unknowns, to be substituted
       const varName = root.value

--- a/app/tests/unit/logic.ts
+++ b/app/tests/unit/logic.ts
@@ -14,12 +14,19 @@ export default () => {
       const tokenizer = new Tokenizer()
 
       it("should parse strings without invalid chars properly", () => {
-        const logicStrings = ["!p", "p & q", "p | q => q", "!(p | q)"]
+        const logicStrings = [
+          "!p",
+          "p & q",
+          "p | q => q",
+          "!(p | q)",
+          "!p <=> q",
+        ]
         const logicParsed = [
           ["!", "p"],
           ["p", "&", "q"],
           ["p", "|", "q", "=>", "q"],
           ["!", "(", "p", "|", "q", ")"],
+          ["!", "p", "<=>", "q"],
         ]
         const variables = [
           {
@@ -36,6 +43,10 @@ export default () => {
           {
             p: [2],
             q: [4],
+          },
+          {
+            p: [1],
+            q: [3],
           },
         ]
         logicStrings.forEach((str, idx) => {
@@ -105,7 +116,13 @@ export default () => {
     const tokenizer = new Tokenizer()
     describe("SyntaxTree.toObj", () => {
       it("should generate an accurate syntax tree", () => {
-        const logicStrings = ["!p", "p & q", "p | q => q", "!(p | q)"]
+        const logicStrings = [
+          "!p",
+          "p & q",
+          "p | q => q",
+          "!(p | q)",
+          "!p <=> q",
+        ]
 
         const treeObjects = [
           {
@@ -182,6 +199,27 @@ export default () => {
               },
             },
           },
+          {
+            left: {
+              left: {},
+              right: {
+                left: {},
+                right: {},
+                type: "VAR",
+                value: "p",
+              },
+              type: "OP",
+              value: "!",
+            },
+            right: {
+              left: {},
+              right: {},
+              type: "VAR",
+              value: "q",
+            },
+            type: "OP",
+            value: "<=>",
+          },
         ]
 
         logicStrings.forEach((str, idx) => {
@@ -237,7 +275,13 @@ export default () => {
     describe("TruthTableGenerator.generate", () => {
       const tokenizer = new Tokenizer()
       it("should correctly evaluate truth table, given a tokenized expression and variable info", () => {
-        const logicStrings = ["!p", "p & q", "!(p | q)", "(p => q) => r"]
+        const logicStrings = [
+          "!p",
+          "p & q",
+          "!(p | q)",
+          "(p => q) => r",
+          "!p <=> q",
+        ]
 
         const answers = [
           { booleans: [[false], [true]], answers: [true, false] },
@@ -271,6 +315,15 @@ export default () => {
               [true, true, true],
             ],
             answers: [false, true, false, true, true, true, false, true],
+          },
+          {
+            answers: [false, true, true, false],
+            booleans: [
+              [false, false],
+              [false, true],
+              [true, false],
+              [true, true],
+            ],
           },
         ]
 

--- a/app/types/Logic.ts
+++ b/app/types/Logic.ts
@@ -5,6 +5,7 @@ export enum LogicToken {
   BINARY_AND = "&",
   BINARY_OR = "|",
   IMPLIES = "=>",
+  BICONDITIONAL = "<=>",
 }
 
 export enum LogicTokenType {

--- a/frontend/constants.js
+++ b/frontend/constants.js
@@ -5,6 +5,7 @@ const LogicToken = {
   BINARY_AND: "&",
   BINARY_OR: "|",
   IMPLIES: "=>",
+  BICONDITIONAL: "<=>",
 }
 
 export { LogicToken }

--- a/frontend/utils.js
+++ b/frontend/utils.js
@@ -98,6 +98,8 @@ const convertTokenizedLogicExpressionToLatex = (expr, isLarge = false) => {
       else if (token.value === LogicToken.BINARY_AND) inner += "\\land"
       else if (token.value === LogicToken.BINARY_OR) inner += "\\lor"
       else if (token.value === LogicToken.IMPLIES) inner += "\\rightarrow"
+      else if (token.value === LogicToken.BICONDITIONAL)
+        inner += "\\leftrightarrow"
     }
   })
 

--- a/pages/logic.js
+++ b/pages/logic.js
@@ -13,6 +13,8 @@ import {
   Tr,
   Th,
   Td,
+  Divider,
+  Heading,
 } from "@chakra-ui/react"
 import { useEffect, useState } from "react"
 
@@ -104,6 +106,7 @@ const Page = () => {
   }, [router.query])
 
   useEffect(() => {
+    MathJax.typeset()
     setLoading(false)
   }, [])
 
@@ -202,6 +205,26 @@ const Page = () => {
             </Table>
           </VStack>
         )}
+        <Divider py={8} />
+        <VStack py={8} spacing={4}>
+          <Heading alignSelf="flex-start">Note: Parsing issues</Heading>
+          <HStack spacing={2} flexWrap="wrap" alignSelf="flex-start">
+            <Code>{LogicToken.IMPLIES}</Code>
+            <Text>and</Text>
+            <Code>{LogicToken.BICONDITIONAL}</Code>
+            <Text>have the same precedence. Therefore, a statement like</Text>
+          </HStack>
+          <Text>$$p \leftrightarrow q \rightarrow r$$</Text>
+          <Text alignSelf="flex-start">
+            is ambiguous. However, the syntax parser assumes a left-to-right
+            evaluation is implied. So this will be interpreted as
+          </Text>
+          <Text>$$(p \leftrightarrow q) \rightarrow r$$</Text>
+          <Text alignSelf="flex-start">
+            Currently the parser does not insert brackets to show this
+            assumption.
+          </Text>
+        </VStack>
       </VStack>
     </Container>
   )


### PR DESCRIPTION
## Problem

Truth table generator did not support `<=>` (biconditional operator)

## Solution

Add functionality to support `<=>` (biconditional operator)

## Checklist

- [x] If the branch was not created off latest `develop`, merge locally
- [x] Using latest `develop` and `master`, do `git diff --stat master` while in `develop` branch. Ensure that the diff is not too large
- [x] If this is a feature, has appropriate documentation been added?

## Notes
