### PR TITLE
Feat/matrix rref status

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ API: `/api/matrix/inverse?matrix=[[1,2],[3,4]]`
 
 Description: Obtains the inverse of a matrix. The algorithm used reduces the original matrix to RREF while playing the same row operations onto an identity matrix of the same dimensions.
 
+### "Echelon status" of a matrix
+
+Frontend page: `/matrix`
+
+Frontend usage: `status [[1,2],[3,4]]`
+
+API: `/api/matrix/status?matrix=[[1,2],[3,4]]`
+
+Description: Returns a string, either "Neither", "Row echelon form", or "Reduced row echelon form". Determines the form of the matrix.
+
 ### Generate a truth table, given a mathematical logic expression
 
 Frontend page: `/logic`

--- a/app/controllers/matrix.ts
+++ b/app/controllers/matrix.ts
@@ -85,8 +85,36 @@ const calcInverse = (req: VercelRequest, res: VercelResponse) => {
   }
 }
 
+const echelonStatus = (req: VercelRequest, res: VercelResponse) => {
+  try {
+    let arr
+    // string array
+    if (Array.isArray(req.query.matrix))
+      arr = JSON.parse(req.query.matrix.join())
+    else arr = JSON.parse(req.query.matrix)
+
+    const rows = arr.length
+    const cols = arr[0].length
+
+    const matrix = new Matrix({
+      rows,
+      columns: cols,
+      entries: arr,
+    })
+
+    const status = matrix.echelonStatus()
+    res.json({
+      type: status,
+    })
+  } catch (err) {
+    const errorCode = _.get(err, "code", 500)
+    res.status(errorCode).json({ message: err.message })
+  }
+}
+
 export default {
   calcDeterminant,
   reduceRREF,
   calcInverse,
+  echelonStatus,
 }

--- a/app/tests/index.ts
+++ b/app/tests/index.ts
@@ -36,6 +36,10 @@ const toTest = [
     method: Matrix.reduceRREF,
   },
   {
+    route: "/matrix/rref",
+    method: Matrix.echelonStatus,
+  },
+  {
     route: "/logic/truthTable",
     method: Logic.generateTruthTable,
   },
@@ -224,6 +228,51 @@ describe("API tests", () => {
     after(stop)
 
     it("should successfully perform rref", async () => {
+      await chai
+        .request(url)
+        .get(route)
+        .query({
+          matrix: "[[1,0,0],[0,4,0],[0,0,2]]",
+        })
+        .then((res) => {
+          chai.expect(res.status).to.equal(200)
+        })
+    })
+    it("should obtain 400 for 3 by 1 matrix with extra data", async () => {
+      // the backend treats this as a 3 by 1 matrix
+      // since it takes the number of elements in the 1st row as the number of columns
+      await chai
+        .request(url)
+        .get(route)
+        .query({
+          matrix: "[[1],[3,4],[5,6]]",
+        })
+        .then((res) => {
+          chai.expect(res.status).to.equal(400)
+          chai.expect(res.body.message).to.equal("Matrix is not rectangle")
+        })
+    })
+    it("should obtain 400 for 3 by 2 matrix with missing data", async () => {
+      // the backend treats this as a 3 by 2 matrix
+      // since it takes the number of elements in the 1st row as the number of columns
+      await chai
+        .request(url)
+        .get(route)
+        .query({
+          matrix: "[[1,2],[3],[5]]",
+        })
+        .then((res) => {
+          chai.expect(res.status).to.equal(400)
+          chai.expect(res.body.message).to.equal("Matrix is not rectangle")
+        })
+    })
+  })
+
+  describe("/api/matrix/status", () => {
+    before(start)
+    after(stop)
+
+    it("should successfully obtain the status of the matrix", async () => {
       await chai
         .request(url)
         .get(route)

--- a/pages/api/[...route].js
+++ b/pages/api/[...route].js
@@ -9,6 +9,7 @@ app.get("/api/test", Test.test)
 app.get("/api/matrix/determinant", Matrix.calcDeterminant)
 app.get("/api/matrix/rref", Matrix.reduceRREF)
 app.get("/api/matrix/inverse", Matrix.calcInverse)
+app.get("/api/matrix/status", Matrix.echelonStatus)
 
 app.get("/api/logic/truthTable", Logic.generateTruthTable)
 

--- a/pages/matrix.js
+++ b/pages/matrix.js
@@ -100,6 +100,24 @@ const Page = () => {
             query: { action: "rref", matrix },
           })
           break
+        case "status":
+          res = await axios.get("/api/matrix/status", {
+            params: {
+              matrix,
+            },
+          })
+          setQuestion(
+            "\\text{Is }" +
+              convert2DArrayToMatrix(matrixArray) +
+              "\\text{ in REF, RREF, or neither?}"
+          )
+          // say Neither instead of None
+          setAnswer(res.data.type === "None" ? "Neither" : res.data.type)
+          setActions([])
+          Router.push({
+            query: { action: "status", matrix },
+          })
+          break
         default:
           setLoading(false)
           setAnswer("")
@@ -181,10 +199,22 @@ const Page = () => {
               <Text>Your input is interpreted as:</Text>
               <Text>${convert2DArrayToMatrix(inputArray)}$</Text>
             </HStack>
-            <HStack spacing={1} bgColor="gray.200" padding={4}>
-              <Text>${question} = $</Text>
-              <Text>${answer}$</Text>
-            </HStack>
+            {router.query.action && router.query.action !== "status" && (
+              <HStack spacing={1} bgColor="gray.200" padding={4}>
+                <>
+                  <Text>${question} = $</Text>
+                  <Text>${answer}$</Text>
+                </>
+              </HStack>
+            )}
+            {router.query.action && router.query.action === "status" && (
+              <VStack spacing={4} bgColor="gray.200" padding={4}>
+                <>
+                  <Text>${question}$</Text>
+                  <Text>Ans: {answer}</Text>
+                </>
+              </VStack>
+            )}
             {router.query.action &&
               router.query.action === "rref" &&
               actions.length > 0 &&


### PR DESCRIPTION
## Problem

Want to add functionality that returns if a matrix is in REF, RREF, or neither.

## Solution

The functionality was already implemented in `Matrix.echelonStatus()`. However, this was not exposed in the API. Thus this PR helps to expose it in the API.

## Checklist

- [x] If the branch was not created off latest `develop`, merge locally
- [x] Using latest `develop` and `master`, do `git diff --stat master` while in `develop` branch. Ensure that the diff is not too large
- [x] If this is a feature, has appropriate documentation been added?

## Notes
