### PR TITLE
fix: only typeset if MathJax is initialized

### DIFF
--- a/pages/logic.js
+++ b/pages/logic.js
@@ -106,7 +106,8 @@ const Page = () => {
   }, [router.query])
 
   useEffect(() => {
-    if (MathJax) MathJax.typeset()
+    if (MathJax && MathJax.typeset && typeof MathJax.typeset === "function")
+      MathJax.typeset()
     setLoading(false)
   }, [])
 

--- a/pages/logic.js
+++ b/pages/logic.js
@@ -106,7 +106,7 @@ const Page = () => {
   }, [router.query])
 
   useEffect(() => {
-    MathJax.typeset()
+    if (MathJax) MathJax.typeset()
     setLoading(false)
   }, [])
 


### PR DESCRIPTION
## Problem

Refer to #60

## Solution

Only attempt `MathJax.typeset()` if `MathJax` is defined

## Checklist

- [x] If the branch was not created off latest `develop`, merge locally
- [x] Using latest `develop` and `master`, do `git diff --stat master` while in `develop` branch. Ensure that the diff is not too large
- [x] If this is a feature, has appropriate documentation been added?

## Notes
